### PR TITLE
Several fixes to improve robustness of action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,10 @@ branding:
 
 inputs:
   test_suite_identifier:
+    required: true
     description: 'Identifier of the Executable Test Suite (etscode) to be run. Example: ogcapi-features-1.0'
   test_session_arguments:
+    required: true
     description: >
       Space-separated string with arguments that are to be sent for running the test session. example:
       'iut=http://pygeoapi:5000'
@@ -17,9 +19,17 @@ inputs:
     required: false
     description: >
       URL for the teamengine instance to use for running the test suite. If not provided, this will spin up a docker
-      container using the [ogccite/teamengine-production:1.0-SNAPSHOT](https://hub.docker.com/r/ogccite/teamengine-production) image.
-      If you specify a custom teamengine URL you may also optonally supply authentication credentials by defining
-      them as secrets - Expected secret names are: `teamengine_username` and `teamengine_password`.
+      container using one of [ogccite/teamengine-beta:1.0-SNAPSHOT](https://hub.docker.com/r/ogccite/teamengine-beta)
+      or [ogccite/teamengine-production:1.0-SNAPSHOT](https://hub.docker.com/r/ogccite/teamengine-production) image,
+      according to the value of the `use_production_ogccite_teamengine_docker_image` input (see below).
+      If you specify a custom teamengine URL you may also optionally supply authentication credentials by defining
+      them as secrets - Expected secret names are: `teamengine_username` and `teamengine_password` (see below).
+  use_production_ogccite_teamengine_docker_image:
+    required: false
+    default: "false"
+    description: >
+      Whether to use the `ogccite/teamengine-production` docker image instead of `ogccite/teamengine-beta`. The beta
+      image is used by default, as it contains more recent versions of test suites.
   teamengine_username:
     required: false
     default: "ogctest"
@@ -56,6 +66,10 @@ outputs:
 
 runs:
   using: 'composite'
+  # Security note: user-controlled inputs are never interpolated directly into shell scripts via ${{ inputs.* }}.
+  # Instead, they are passed through each step's `env:` block and referenced as quoted shell variables ("$VAR").
+  # This prevents script injection, since ${{ }} expressions are expanded textually before the shell runs,
+  # while environment variable expansion treats values as data rather than code.
   steps:
     - name: "Add action path to the global path"
       shell: bash
@@ -66,13 +80,13 @@ runs:
       run: |
         echo "ACTION_NORMALIZED_PATH=$(realpath -m ${{ github.action_path }})" >> "${GITHUB_OUTPUT}"
     - name: "Install uv"
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: "0.6.13"
         enable-cache: true
         cache-dependency-glob: "${{ steps.normalize_action_path.outputs.ACTION_NORMALIZED_PATH }}/uv.lock"
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version-file: "${{ github.action_path }}/pyproject.toml"
     - name: "Install ogc-cite-runner"
@@ -86,32 +100,53 @@ runs:
         uv sync --frozen
     - name: "Start TEAM engine container"
       if: ${{ !inputs.teamengine_url }}
+      env:
+        USE_PRODUCTION_IMAGE: ${{ inputs.use_production_ogccite_teamengine_docker_image }}
       shell: "bash"
-      run: >
-        docker run
-        --detach
-        --rm
-        --name teamengine
-        --add-host=host.docker.internal:host-gateway
-        --publish 9080:8080
-        ogccite/teamengine-production:1.0-SNAPSHOT
+      run: |
+        if [ "$USE_PRODUCTION_IMAGE" = "true" ]; then
+          TEAMENGINE_IMAGE="ogccite/teamengine-production:1.0-SNAPSHOT"
+        else
+          TEAMENGINE_IMAGE="ogccite/teamengine-beta:1.0-SNAPSHOT"
+        fi
+        docker run \
+          --detach \
+          --rm \
+          --name teamengine \
+          --add-host=host.docker.internal:host-gateway \
+          --publish 9080:8080 \
+          ${TEAMENGINE_IMAGE}
     - name: "Run ogc-cite-runner"
       id: "run_cite_runner"
+      env:
+        TEAMENGINE_URL_INPUT: ${{ inputs.teamengine_url }}
+        USE_PRODUCTION_IMAGE: ${{ inputs.use_production_ogccite_teamengine_docker_image }}
+        NETWORK_TIMEOUT: ${{ inputs.network_timeout_seconds }}
+        TEST_SUITE_ID: ${{ inputs.test_suite_identifier }}
+        TEAMENGINE_USERNAME: ${{ inputs.teamengine_username }}
+        TEAMENGINE_PASSWORD: ${{ inputs.teamengine_password }}
+        TEST_SESSION_ARGS: ${{ inputs.test_session_arguments }}
       shell: "bash --noprofile --norc -o pipefail {0}"
       run: |
         cd ${{ github.action_path }}
         RAW_PATH=raw-result.xml
+        if [ -n "$TEAMENGINE_URL_INPUT" ]; then
+          TEAMENGINE_URL="$TEAMENGINE_URL_INPUT"
+        elif [ "$USE_PRODUCTION_IMAGE" = "true" ]; then
+          TEAMENGINE_URL="http://localhost:9080/teamengine"
+        else
+          TEAMENGINE_URL="http://localhost:9080/te2"
+        fi
+        read -ra session_args <<< "$TEST_SESSION_ARGS"
         uv run ogc-cite-runner \
-            --network-timeout=${{ inputs.network_timeout_seconds }} \
+            --network-timeout="$NETWORK_TIMEOUT" \
             execute-test-suite-from-github-actions \
-            ${{ inputs.teamengine_url || 'http://localhost:9080/teamengine' }} \
-            ${{ inputs.test_suite_identifier }} \
+            "$TEAMENGINE_URL" \
+            "$TEST_SUITE_ID" \
             --output-format=raw \
-            --teamengine-username=${{ inputs.teamengine_username }} \
-            --teamengine-password=${{ inputs.teamengine_password }} \
-            $(echo -e ${{ inputs.test_session_arguments }}) 1> ${RAW_PATH}
+            "${session_args[@]}" 1> ${RAW_PATH}
         if [ $? -ne 0 ]; then
-            echo "Unable to use TeamEngine to execute test suite ${{ inputs.test_suite_identifier }} with arguments ${{ inputs.test_session_arguments }}"
+            echo "Unable to use TeamEngine to execute test suite $TEST_SUITE_ID with arguments $TEST_SESSION_ARGS"
             exit 1
         fi
         echo "RAW_RESULT_OUTPUT_PATH=${{ steps.normalize_action_path.outputs.ACTION_NORMALIZED_PATH }}/${RAW_PATH}" >> "${GITHUB_OUTPUT}"
@@ -141,7 +176,7 @@ runs:
             ${RAW_PATH}
         )" >> "${GITHUB_OUTPUT}"
     - name: "Store execution results as artifacts"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: 'execution-results-${{ inputs.test_suite_identifier }}'
         path: |
@@ -150,11 +185,12 @@ runs:
     - name: "Stop teamengine container"
       if: ${{ always() && !inputs.teamengine_url }}
       shell: "bash"
-      run: docker stop teamengine
+      run: docker stop teamengine || true
     - name: "Set action exit code"
       shell: "bash"
       run: |
-        if [ ${{ steps.run_cite_runner.outputs.CITE_RUNNER_EXIT_CODE}} -eq 0 ]; then
+        EXIT_CODE="${{ steps.run_cite_runner.outputs.CITE_RUNNER_EXIT_CODE }}"
+        if [ "${EXIT_CODE:-1}" -eq 0 ]; then
             echo "::notice::Test suite has passed"
             exit 0
         else

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,17 +53,34 @@ In a brief nutshell:
 
 6. Stand up a docker container with a local teamengine instance:
 
-    ```shell
-    docker run \
-        --rm \
-        --name=teamengine \
-        --add-host=host.docker.internal:host-gateway \
-        --publish=9080:8080 \
-        ogccite/teamengine-production:1.0-SNAPSHOT
-    ```
+    === "teamengine-beta"
 
-    You should now be able to use `http:localhost:9080/teamengine` as the teamengine URL in
-    ogc-cite-runner.
+        ```shell
+        docker run \
+            --rm \
+            --name=teamengine \
+            --add-host=host.docker.internal:host-gateway \
+            --publish=9080:8080 \
+            ogccite/teamengine-beta:1.0-SNAPSHOT
+        ```
+
+        You should now be able to use `http:localhost:9080/te2` as the teamengine URL in
+        ogc-cite-runner.
+
+    === "teamengine-production"
+
+        ```shell
+        docker run \
+            --rm \
+            --name=teamengine \
+            --add-host=host.docker.internal:host-gateway \
+            --publish=9080:8080 \
+            ogccite/teamengine-production:1.0-SNAPSHOT
+        ```
+
+        You should now be able to use `http:localhost:9080/teamengine` as the teamengine URL in
+        ogc-cite-runner.
+
 
     !!! note
 
@@ -124,11 +141,16 @@ result matches what is expected.
 If you want to work on documentation, you can start the mkdocs server with:
 
  ```shell
- uv run mkdocs serve
+ uv run mkdocs serve --livereload
  ```
 
+!!! note
+
+    The `--livereload` flag must be passed explicitly due to a [known issue with mkdocs and click](https://github.com/mkdocs/mkdocs/issues/4055)
+    that causes live reload to be silently disabled when omitted.
+
 Now edit files under the `/docs` directory and check whether they match your expected result in the mkdocs dev server,
-which would be running at `http://localhost:8000/ogc-cite-runner/
+which would be running at `http://localhost:8000/ogc-cite-runner/`
 
 
 ## Release management

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,20 +49,20 @@ jobs:
 Run the same test suite as a standalone CLI application:
 
 ```shell
-docker pull ogccite/teamengine-production:1.0-SNAPSHOT
+docker pull ogccite/teamengine-beta:1.0-SNAPSHOT
 docker run \
     --rm \
     --name=teamengine \
     --add-host=host.docker.internal:host-gateway \
     --publish=9080:8080 \
-    ogccite/teamengine-production:1.0-SNAPSHOT
+    ogccite/teamengine-beta:1.0-SNAPSHOT
 
 pipx install ogc-cite-runner
 
 ogc-cite-runner execute-test-suite \
-    http://localhost:8080/teamengine \
+    http://localhost:9080/te2 \
     ogcapi-features-1.0 \
-    --test-suite-input iut http://host.docker.internal:5001
+    --suite-input iut http://host.docker.internal:5001
 ```
 
 

--- a/docs/running-as-github-action.md
+++ b/docs/running-as-github-action.md
@@ -110,6 +110,22 @@ When run as a GitHub action, ogc-cite-runner expects the following inputs to be 
             [docker engine docs:material-open-in-new:]{: target="blank_" } for more detail.
 
 
+### `use_production_ogccite_teamengine_docker_image`
+
+- **Required**: No (defaults to `'false'`)
+- **Description**: Whether to use the `ogccite/teamengine-production` docker image instead of
+  `ogccite/teamengine-beta` when spinning up a local TeamEngine container. The beta image is used
+  by default, as it contains more recent versions of test suites.
+
+    This input is only relevant when `teamengine_url` is not provided.
+
+    Example:
+
+    ```yaml
+    use_production_ogccite_teamengine_docker_image: "true"
+    ```
+
+
 ### `teamengine_url`
 
 - **Required**: No (defaults to not set)
@@ -123,8 +139,11 @@ When run as a GitHub action, ogc-cite-runner expects the following inputs to be 
     authentication credentials.
 
     !!! note
-        The value of `teamengine_url` must be the URL of the landing page of
-        the TeamEngine service, which usually is located at the `/teamengine` path.
+        The value of `teamengine_url` must be the URL of the landing page of the TeamEngine service.
+        The path depends on the image being used:
+
+        - `ogccite/teamengine-production` — landing page is at `/teamengine`
+        - `ogccite/teamengine-beta` — landing page is at `/te2`
 
     Examples:
 
@@ -442,7 +461,8 @@ relevant steps consist of calling ogc-cite-runner as a standalone CLI applicatio
 
     1. The first execution is where the test suite is actually run. The ogc-cite-runner
        `execute-test-suite-from-github-actions` CLI command is invoked with the `--output-format raw` flag
-       and the raw XML result returned by TeamEngine is stored as `raw-result.xml`
+       and the raw XML result returned by TeamEngine is stored as `raw-result.xml`. TeamEngine credentials
+       are passed via environment variables rather than CLI flags.
 
     2. The second execution parses the raw result and outputs a full report to the logs.
        ogc-cite-runner's `parse-result` CLI command is invoked with the `--output-format console` flag. Depending on

--- a/docs/running-as-standalone-cli.md
+++ b/docs/running-as-standalone-cli.md
@@ -147,8 +147,8 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
 | name | description |
 | ---- | ----------- |
 | `--help` | Show information on how to run the command, including a description of arguments and options |
-| `--teamengine-username` | Username for authenticating with teamengine |
-| `--teamengine-password` | Password for authenticating with teamengine |
+| `--teamengine-username` | Username for authenticating with teamengine. Can also be set via the `TEAMENGINE_USERNAME` environment variable. |
+| `--teamengine-password` | Password for authenticating with teamengine. Can also be set via the `TEAMENGINE_PASSWORD` environment variable. Prefer the environment variable over the CLI flag to avoid the password being visible in process listings. |
 | `--suite-input` | Inputs expected by teamengine for running the test suite specified with TEST_SUITE_IDENTIFIER. These vary depending on the test suite.<br><br>This parameter can be specified multiple times.<br><br>Each parameter must be specified as a name and a value, separated by the space character (_i.e._ `--suite-input {name} {value}`).<br><br>**Ensure you read the warning above on how to provide the URL of the service being tested.**<br><br>Example: `--suite-input iut http://host.docker.internal:5000 --suite-input noofcollections -1`|
 | `--output-format` | Format for the ogc-cite-runner result. Available options are:<br><ul><li><code>console</code> - Return results in a format suitable for reading in the terminal - This is the default</li><li><code>json</code> - Return results as JSON. This is useful for piping the results to other commands for further processing.</li><li><code>markdown</code> - Return results as a Markdown document.</li><li><code>raw</code> - Return the raw results as provided by teamengine. This is an XML document.</li></ul>
 | `--with-summary`/`--without-summary` | Whether the output should include a summary. This is enabled by default. Disable it by providing `--without-summary` |

--- a/src/ogc_cite_runner/main.py
+++ b/src/ogc_cite_runner/main.py
@@ -47,6 +47,7 @@ _teamengine_username_option = typing.Annotated[
     typer.Option(
         help="Username for authenticating with teamengine",
         parser=_parse_pydantic_secret_str,
+        envvar="TEAMENGINE_USERNAME",
     ),
 ]
 _teamengine_password_option = typing.Annotated[
@@ -54,6 +55,7 @@ _teamengine_password_option = typing.Annotated[
     typer.Option(
         help="Password for authenticating with teamengine",
         parser=_parse_pydantic_secret_str,
+        envvar="TEAMENGINE_PASSWORD",
     ),
 ]
 _output_format_option = typing.Annotated[


### PR DESCRIPTION
- defaulted to using teamengine beta image (fixes #117)
- added flag for using teamengine production (fixes #114)
- user inputs are not interpolated directly anymore, but rather passed via env (fixes #116)
- using SHA identifiers for third-party actions
- updated documentation (fixes #113)  